### PR TITLE
add ability to set permissions for userlist.txt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,9 @@ class pgbouncer (
   $listen_port = '6432',
   $admin_users = 'postgres',
   $stats_users = 'postgres',
+  $owner = 'pgbouncer',
+  $owner_group = 'pgbouncer',
+  $userlist_mode = '0600',
   $auth_type = 'trust',
   $auth_list = undef,
   $pool_mode = 'transaction'
@@ -119,6 +122,9 @@ class pgbouncer (
     ensure  => file,
     content => template('pgbouncer/userlist.txt.erb'),
     require => File[$conf],
+    owner   => $owner,
+    group   => $owner_group,
+    mode    => $userlist_mode,
   }
 
   service {'pgbouncer':


### PR DESCRIPTION
In many cases, userlist.txt may contain sensitive information. This request adds a way to configure owner and permissions of userlist.txt (this could default to root / root / 644 instead of my examples to keep existing behavior).

Otherwise, AFAICT, it's not possible to define the file somewhere else, since it's already defined here.
